### PR TITLE
#139 Feature - User can delete own cleanups

### DIFF
--- a/trashtalk/apps/cleanups/tests/test_views.py
+++ b/trashtalk/apps/cleanups/tests/test_views.py
@@ -171,3 +171,13 @@ class CleanupTemplateViewsTestCase(TestCase):
         response = self.client.post(url, data=data,
                                     content_type='application/x-www-form-urlencoded')
         self.assertEqual(response.status_code, 200)
+
+    def test_cleanup_delete_success(self):
+        cleanup = CleanupFactory(host=self.user)
+        url = reverse('cleanup-delete', args=[cleanup.id])
+        self.client.force_login(self.user)
+
+        response = self.client.delete(url, follow=True)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertRedirects(response, reverse('dashboard'))

--- a/trashtalk/apps/cleanups/views/template_views.py
+++ b/trashtalk/apps/cleanups/views/template_views.py
@@ -86,3 +86,15 @@ def cleanup_update(request, *args, **kwargs):
     cleanup = Cleanup.objects.get(id=kwargs['pk'])
     return render(request, 'cleanups/detail.html',
                   {'cleanup': cleanup, 'participants': cleanup.participants.all()})
+
+
+@host_required
+@api_view(['POST', 'DELETE'])
+def cleanup_delete(request, *args, **kwargs):
+    cleanup = Cleanup.objects.get(id=kwargs['pk'])
+    try:
+        cleanup.delete()
+    except (AssertionError, Exception):
+        logger.exception('Error while deleting cleanup.')
+        redirect(cleanup)
+    return redirect('dashboard')

--- a/trashtalk/urls.py
+++ b/trashtalk/urls.py
@@ -22,7 +22,7 @@ from django.conf import settings
 from accounts.views import (LoginView, UserDashboardView, user_signup_view, user_signup_create)
 from cleanups.views.template_views import (cleanup_new, cleanup_edit, cleanup_list,
                                            cleanup_show, cleanup_create, cleanup_update,
-                                           cleanup_join_view)
+                                           cleanup_join_view, cleanup_delete)
 
 urlpatterns = [
     # Homepage
@@ -52,6 +52,7 @@ urlpatterns = [
     url(r'^cleanups/(?P<pk>[0-9]+)/edit/$', cleanup_edit, name='cleanup-edit'),
     url(r'^cleanups/(?P<pk>[0-9]+)/update/$', cleanup_update, name='cleanup-update'),
     url(r'^cleanups/(?P<pk>[0-9]+)/join/$', cleanup_join_view, name='join-cleanup'),
+    url(r'^cleanups/(?P<pk>[0-9]+)/delete$', cleanup_delete, name='cleanup-delete'),
     url(r'^cleanups/(?P<pk>[0-9]+)/$', cleanup_show, name='cleanup-detail'),
 
     # Development Only


### PR DESCRIPTION
Adds a view and url to allow users to delete cleanups they're hosting.

__Friendly Reminder Checklist:__
- [x] Code follows guidelines [follows guidelines](https://github.com/openoakland/TrashTalk/blob/master/CONTRIBUTE.md#codeguidelines
- [x] Tests have passed locally.
- [x] Linter score is 7.5 or above.
- [x] References to relevant issues added in the description.
- [x] Updates to migrations, tests and requirements are included as necessary.

@protosac

__Description:__
EDIT ME.
