### PR TITLE
#162 JWT Authentication for API

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -6,6 +6,7 @@ Django==2.0.2
 djangorestframework==3.7.7
 django-extensions==1.9.9
 django-model-utils==3.1.1
+djangorestframework-jwt             # Works but incompatible. Add version when Django 2.0 added
 
 # ^^^^^^^^^^^^^^^^^^^^^^
 # DATABASE MODULES

--- a/trashtalk/api_urls.py
+++ b/trashtalk/api_urls.py
@@ -1,5 +1,7 @@
 from django.conf.urls import url
 
+from rest_framework_jwt.views import obtain_jwt_token, refresh_jwt_token, verify_jwt_token
+
 from accounts.views import UserCreateAPIView, UserListAPIView, UserDetailAPIView
 from cleanups.views.api_views import (CleanupListCreateAPIView, CleanupDetailAPIView,
                                       LocationListCreateView)
@@ -7,6 +9,12 @@ from cleanups.views.api_views import (CleanupListCreateAPIView, CleanupDetailAPI
 app_name = 'trashtalk'
 
 urlpatterns = [
+    # JWT Auth
+    url(r'^token/', obtain_jwt_token),
+    url(r'^token-refresh/', refresh_jwt_token),
+    url(r'^token-verify/', verify_jwt_token),
+
+
     url(r'^cleanups/$', CleanupListCreateAPIView.as_view(), name='cleanups'),
     url(r'^cleanups/(?P<pk>[0-9]+)/$', CleanupDetailAPIView.as_view(), name='cleanup-detail'),
     url(r'^locations/$', LocationListCreateView.as_view(), name='locations'),

--- a/trashtalk/apps/accounts/views.py
+++ b/trashtalk/apps/accounts/views.py
@@ -10,7 +10,7 @@ from rest_framework.generics import (CreateAPIView, GenericAPIView, ListAPIView,
                                      RetrieveUpdateDestroyAPIView)
 from rest_framework.permissions import (IsAdminUser, IsAuthenticatedOrReadOnly)
 from rest_framework.parsers import FormParser
-from rest_framework.permissions import IsAuthenticated
+from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.renderers import TemplateHTMLRenderer
 from rest_framework.response import Response
 from .serializers import User, UserSerializer
@@ -48,6 +48,7 @@ class LoginView(GenericAPIView):
     queryset = User.objects.all()
     renderer_classes = [TemplateHTMLRenderer]
     parser_classes = [FormParser,]
+    permission_classes = (AllowAny,)
     template_name = 'index.html'
 
     def get(self, request):

--- a/trashtalk/settings/common.py
+++ b/trashtalk/settings/common.py
@@ -19,7 +19,7 @@ Settings is divided into several core sections:
 
 More settings can be added at any time.
 """
-
+import datetime
 import os
 
 from os.path import dirname
@@ -147,6 +147,56 @@ AUTH_PASSWORD_VALIDATORS = [
     },
 ]
 
+REST_FRAMEWORK = {
+    'DEFAULT_PERMISSION_CLASSES': (
+        'rest_framework.permissions.IsAuthenticated',
+    ),
+    'DEFAULT_AUTHENTICATION_CLASSES': (
+        'rest_framework_jwt.authentication.JSONWebTokenAuthentication',
+        'rest_framework.authentication.SessionAuthentication',
+        'rest_framework.authentication.BasicAuthentication',
+    ),
+    'DEFAULT_PARSER_CLASSES': (
+        'rest_framework.parsers.JSONParser',
+    ),
+}
+
+JWT_AUTH = {
+    # TODO: Issue #162 -- JWT auto-refresh at expiry
+    'JWT_EXPIRATION_DELTA': datetime.timedelta(days=7),
+    'JWT_REFRESH_EXPIRATION_DELTA': datetime.timedelta(days=30),
+
+    # Default Settings: Uncomment and modify as needed
+    # 'JWT_ENCODE_HANDLER':
+    # 'rest_framework_jwt.utils.jwt_encode_handler',
+
+    # 'JWT_DECODE_HANDLER':
+    # 'rest_framework_jwt.utils.jwt_decode_handler',
+
+    # 'JWT_PAYLOAD_HANDLER':
+    # 'rest_framework_jwt.utils.jwt_payload_handler',
+
+    # 'JWT_PAYLOAD_GET_USER_ID_HANDLER':
+    # 'rest_framework_jwt.utils.jwt_get_user_id_from_payload_handler',
+
+    # 'JWT_RESPONSE_PAYLOAD_HANDLER':
+    # 'rest_framework_jwt.utils.jwt_response_payload_handler',
+
+    # 'JWT_SECRET_KEY': settings.SECRET_KEY,
+    # 'JWT_GET_USER_SECRET_KEY': None,
+    # 'JWT_PUBLIC_KEY': None,
+    # 'JWT_PRIVATE_KEY': None,
+    # 'JWT_ALGORITHM': 'HS256',
+    # 'JWT_VERIFY': True,
+    # 'JWT_VERIFY_EXPIRATION': True,
+    # 'JWT_LEEWAY': 0,
+    # 'JWT_AUDIENCE': None,
+    # 'JWT_ISSUER': None,
+    # 'JWT_ALLOW_REFRESH': True,
+    # 'JWT_AUTH_HEADER_PREFIX': 'JWT',
+    # 'JWT_AUTH_COOKIE': None,
+
+}
 # =======================================================================
 # STATIC AND MEDIA
 # https://docs.djangoproject.com/en/1.11/howto/static-files/

--- a/trashtalk/urls.py
+++ b/trashtalk/urls.py
@@ -16,7 +16,6 @@ Including another URLconf
 from django.conf.urls import url, include, static
 from django.contrib import admin
 from django.contrib.auth import views as auth_views
-
 from django.conf import settings
 
 from accounts.views import (LoginView, UserDashboardView, user_signup_view, user_signup_create)


### PR DESCRIPTION
Adds token authentication to the API #162
This changes adds the foundation. See the issue for additional features
to be added next.

- djangorestframework-jwt
- Update settings in `common.py`
- Update `api_urls` with endpoints

The package comes with tests, no additional tests needed.

__Friendly Reminder Checklist:__
- [x] Code follows guidelines [follows guidelines](https://github.com/openoakland/TrashTalk/blob/master/CONTRIBUTE.md#codeguidelines
- [x] Tests have passed locally.
- [x] Linter score is 7.5 or above.
- [x] References to relevant issues added in the description.
- [x] Updates to migrations, tests and requirements are included as necessary.

@protosac

__Description:__
EDIT ME.
